### PR TITLE
Add floorplan AI example app

### DIFF
--- a/examples/floorplan_ai/README.md
+++ b/examples/floorplan_ai/README.md
@@ -1,0 +1,21 @@
+# Floorplan AI Example
+
+This example demonstrates a simple Flask app that accepts a floorplan
+image, runs a very basic computer vision algorithm to locate door-like
+shapes, and returns the coordinates and annotated image.
+
+The detection uses OpenCV to find contours after edge detection. It is
+only meant as a starting point. For real projects, consider training a
+proper model or integrating an existing object detection API.
+
+## Usage
+
+Install dependencies and run the app:
+
+```bash
+pip install Flask Pillow numpy opencv-python-headless
+python app.py
+```
+
+Open `http://localhost:5000` and upload a floorplan image to see
+detected access points.

--- a/examples/floorplan_ai/app.py
+++ b/examples/floorplan_ai/app.py
@@ -1,0 +1,58 @@
+import os
+import uuid
+from flask import Flask, render_template, request, send_from_directory, jsonify
+import cv2
+import numpy as np
+
+app = Flask(__name__)
+app.config['UPLOAD_FOLDER'] = os.path.join(app.root_path, 'static', 'uploads')
+app.config['RESULT_FOLDER'] = os.path.join(app.root_path, 'static', 'results')
+
+os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
+os.makedirs(app.config['RESULT_FOLDER'], exist_ok=True)
+
+def detect_access_points(image_path):
+    """Detect door-like shapes and return bounding boxes."""
+    img = cv2.imread(image_path)
+    if img is None:
+        return []
+    gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+    blur = cv2.GaussianBlur(gray, (5, 5), 0)
+    edges = cv2.Canny(blur, 50, 150)
+    contours, _ = cv2.findContours(edges, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    boxes = []
+    for cnt in contours:
+        x, y, w, h = cv2.boundingRect(cnt)
+        aspect = w / float(h) if h != 0 else 0
+        if 0.1 < aspect < 10 and 10 < w < 200 and 10 < h < 200:
+            boxes.append((x, y, w, h))
+    return boxes
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/upload', methods=['POST'])
+def upload():
+    file = request.files.get('file')
+    if not file:
+        return 'No file uploaded', 400
+    filename = f"{uuid.uuid4().hex}_{file.filename}"
+    path = os.path.join(app.config['UPLOAD_FOLDER'], filename)
+    file.save(path)
+
+    boxes = detect_access_points(path)
+    img = cv2.imread(path)
+    for (x, y, w, h) in boxes:
+        cv2.rectangle(img, (x, y), (x + w, y + h), (0, 255, 0), 2)
+    result_name = f"result_{filename}"
+    result_path = os.path.join(app.config['RESULT_FOLDER'], result_name)
+    cv2.imwrite(result_path, img)
+    return render_template('result.html', image=result_name, boxes=boxes)
+
+@app.route('/results/<path:filename>')
+def results(filename):
+    return send_from_directory(app.config['RESULT_FOLDER'], filename)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/examples/floorplan_ai/templates/index.html
+++ b/examples/floorplan_ai/templates/index.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<title>Floorplan Uploader</title>
+<h1>Upload Floorplan</h1>
+<form method=post action="/upload" enctype=multipart/form-data>
+  <input type=file name=file required>
+  <input type=submit value=Upload>
+</form>

--- a/examples/floorplan_ai/templates/result.html
+++ b/examples/floorplan_ai/templates/result.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<title>Detection Result</title>
+<h1>Detected Access Points</h1>
+<img src="/results/{{ image }}" alt="result image">
+<p>{{ boxes|length }} potential access points found.</p>
+<ul>
+{% for x, y, w, h in boxes %}
+  <li>x={{x}}, y={{y}}, w={{w}}, h={{h}}</li>
+{% endfor %}
+</ul>
+<a href="/">Upload another</a>


### PR DESCRIPTION
## Summary
- create example `floorplan_ai` app
- detect simple access points in a floorplan image using OpenCV
- add upload and result templates

## Testing
- `pytest -W ignore::DeprecationWarning tests/test_basic.py::test_url_mapping -q`

------
https://chatgpt.com/codex/tasks/task_e_688c849aa48883299cdce6f80d5e2091